### PR TITLE
build: switch coverage provider from istanbul to v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
 				"@eslint/compat": "^2.0.0",
 				"@eslint/js": "^10.0.1",
 				"@types/node": "^25.0.2",
-				"@vitest/coverage-istanbul": "^4.0.3",
 				"@vitest/coverage-v8": "^4.0.3",
 				"eslint": "^10.4.0",
 				"eslint-config-prettier": "^10.1.2",
@@ -36,6 +35,8 @@
 			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
@@ -51,6 +52,8 @@
 			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -61,6 +64,8 @@
 			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.7",
 				"@babel/generator": "^7.29.7",
@@ -92,6 +97,8 @@
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -102,6 +109,8 @@
 			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/parser": "^7.29.7",
 				"@babel/types": "^7.29.7",
@@ -119,6 +128,8 @@
 			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.29.7",
 				"@babel/helper-validator-option": "^7.29.7",
@@ -136,6 +147,8 @@
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -146,6 +159,8 @@
 			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -156,6 +171,8 @@
 			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/traverse": "^7.29.7",
 				"@babel/types": "^7.29.7"
@@ -170,6 +187,8 @@
 			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.29.7",
 				"@babel/helper-validator-identifier": "^7.29.7",
@@ -208,6 +227,8 @@
 			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -218,6 +239,8 @@
 			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/template": "^7.29.7",
 				"@babel/types": "^7.29.7"
@@ -258,6 +281,8 @@
 			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.7",
 				"@babel/parser": "^7.29.7",
@@ -273,6 +298,8 @@
 			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.7",
 				"@babel/generator": "^7.29.7",
@@ -1303,6 +1330,8 @@
 			"integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1313,6 +1342,8 @@
 			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -1324,6 +1355,8 @@
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -2076,6 +2109,8 @@
 			"integrity": "sha512-EbruXy+E9MJk+y7sFzriYfoI4JP2Ow+SyWDkewFOWFjzrbQBHlEgi6dGE7pxge8Z+W+7oJOxAVVb6mQHKCCZlw==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.29.0",
 				"@istanbuljs/schema": "^0.1.3",
@@ -2361,6 +2396,8 @@
 			"integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.cjs"
 			},
@@ -2427,6 +2464,8 @@
 				}
 			],
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.12",
 				"caniuse-lite": "^1.0.30001782",
@@ -2460,7 +2499,9 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"license": "CC-BY-4.0"
+			"license": "CC-BY-4.0",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/chai": {
 			"version": "6.2.2",
@@ -2564,7 +2605,9 @@
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.363.tgz",
 			"integrity": "sha512-VjUKPyWzGnT1fujlkEGC/BvN70Hh70KXtAqcmniXviYlJC/ivcT+BWGPyxWVbJZLfvtKR6dqg1L7T7pgAMBtWA==",
 			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/enquirer": {
 			"version": "2.4.1",
@@ -2635,6 +2678,8 @@
 			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -3084,6 +3129,8 @@
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -3331,7 +3378,9 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.1",
@@ -3352,6 +3401,8 @@
 			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
@@ -3386,6 +3437,8 @@
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -3714,6 +3767,8 @@
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
 			}
@@ -3855,6 +3910,8 @@
 			"integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -4732,6 +4789,8 @@
 				}
 			],
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"escalade": "^3.2.0",
 				"picocolors": "^1.1.1"
@@ -4995,7 +5054,9 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
 		"@eslint/compat": "^2.0.0",
 		"@eslint/js": "^10.0.1",
 		"@types/node": "^25.0.2",
-		"@vitest/coverage-istanbul": "^4.0.3",
 		"@vitest/coverage-v8": "^4.0.3",
 		"eslint": "^10.4.0",
 		"eslint-config-prettier": "^10.1.2",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,8 +4,7 @@ export default defineConfig({
 	test: {
 		coverage: {
 			reportsDirectory: './coverage-test',
-			provider: 'istanbul', // or 'v8'
-			// provider: 'v8',
+			provider: 'v8',
 			include: ['src/**/*.{js,ts}'],
 			reporter: ['text', 'html', 'clover', 'json', 'lcov']
 		}


### PR DESCRIPTION
## Summary

- `@vitest/coverage-istanbul` writes lcov **without** `DA:` (per-line hit counts) — only `FN/FNDA` and `BRDA`. SonarCloud reads lcov and, in the absence of `DA:`, treats every executable line as uncovered → reports **0.0% New Code Coverage**, fails the Quality Gate even though local `npm run coverage` shows ~98% (istanbul's text reporter has hit counts internally; it just doesn't export them to lcov).
- Switch `vitest.config.ts` to `provider: 'v8'`. v8 emits a full lcov with `DA:<line>,<hits>` for every executable line, e.g. `DA:8,36` for the loop in `digraph.ts:8` that Sonar previously flagged red.
- Drop `@vitest/coverage-istanbul` from devDependencies — `@vitest/coverage-v8` was already declared and is now the sole provider.

## Test plan

- [x] `npm run lint`
- [x] `npm run check` / `npm run check:test`
- [x] `npm test` (vitest + benchmark)
- [x] `npm run coverage` — produces lcov with 106 `DA:` records for `digraph.ts` (was 0 before)
- [x] CI green on Node 22 + 24
- [ ] Sonar Quality Gate passes (New Code Coverage no longer 0%)