### PR TITLE
build: fix sonar lcov.reportPaths

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -2,9 +2,9 @@ sonar.organization=kt-npm-modules
 sonar.projectKey=kt-npm-modules_digraph-js
 sonar.projectName=digraph-js
 
-sonar.sources=./src
-sonar.tests=./tests
-sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+sonar.sources=src
+sonar.tests=tests
+sonar.javascript.lcov.reportPaths=coverage*/**/lcov.info
 
 # sonar.exclusions=src/routes/**/*
-sonar.cpd.exclusions=./tests/**/*
+sonar.cpd.exclusions=tests/**/*


### PR DESCRIPTION
## Summary

The real reason SonarCloud reported `0.0% New Code Coverage` was not the lcov format — istanbul's lcov was fine. It was that `sonar-project.properties` (a symlink to `.sonarcloud.properties`) declared:

```
sonar.javascript.lcov.reportPaths=./coverage/lcov.info
```

CI never produces that path. Vitest writes to `coverage-test/`; the workflow then renames it to `coverage-test-node22/` and `coverage-test-node24/` per matrix entry and drops both at the repo root for the sonar job. Sonar opened nothing → no coverage data → 0%.

Fix:
```
sonar.javascript.lcov.reportPaths=coverage*/**/lcov.info
```
matches whatever directory the workflow produces. Same pattern as our chessboard template. Also dropped the `./` prefixes on `sonar.sources` / `sonar.tests` / `sonar.cpd.exclusions` for consistency.

The previous PR (#91) switched the provider to v8. We're keeping it — v8 is the vitest default, faster on the benchmark suite, and removed one redundant devDependency. But it wasn't actually the fix; this is.

## Test plan

- [x] `cat sonar-project.properties` shows the new path
- [ ] CI green on Node 22 + 24
- [ ] SonarCloud Code Analysis sees coverage data and Quality Gate passes