### PR TITLE
fix: publish CHANGELOG.md and tighten check scripts

### DIFF
--- a/.changeset/publish-changelog-and-tighten-checks.md
+++ b/.changeset/publish-changelog-and-tighten-checks.md
@@ -1,0 +1,11 @@
+---
+'@ktarmyshov/digraph-js': patch
+---
+
+Publish `CHANGELOG.md` in the package tarball and tighten type-check scripts.
+
+- `files` now includes `CHANGELOG.md` (npm does not auto-include it the way it does `README.md` / `LICENSE`). Removed redundant negative globs (`!tests`, `!examples`, `!benchmarks`) that were no-ops since none of those paths were ever in the whitelist.
+- `check` now runs `tsc --project tsconfig.json --noEmit` instead of bare `tsc --skipLibCheck --noEmit`, mirroring `npm-typescript-template`.
+- `check:test` no longer passes redundant `--skipLibCheck` (the base config already sets it).
+
+No public API changes.

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
 		"prepack": "publint",
 		"format": "prettier --write .",
 		"lint": "prettier --check . && eslint .",
-		"check": "tsc --skipLibCheck --noEmit",
-		"check:test": "tsc --project tsconfig-test.json --skipLibCheck",
+		"check": "tsc --project tsconfig.json --noEmit",
+		"check:test": "tsc --project tsconfig-test.json",
 		"benchmark": "cd tests/benchmarks/webpack && tsx ./find-cycles.ts",
 		"test": "npm run check:test && vitest run && npm run benchmark",
 		"coverage": "vitest run --coverage",
@@ -53,11 +53,9 @@
 	},
 	"files": [
 		"dist",
+		"CHANGELOG.md",
 		"!dist/**/*.test.*",
-		"!dist/**/*.spec.*",
-		"!tests",
-		"!examples",
-		"!benchmarks"
+		"!dist/**/*.spec.*"
 	],
 	"devDependencies": {
 		"@changesets/cli": "^2.28.1",


### PR DESCRIPTION
Small follow-up after the major rework in #89.

## What

- `package.json` `files`: add `CHANGELOG.md`, drop no-op `!tests` / `!examples` / `!benchmarks`. CHANGELOG was missing from the published tarball (npm does not auto-include it like README/LICENSE).
- `check` script: `tsc --skipLibCheck --noEmit` → `tsc --project tsconfig.json --noEmit` for parity with `npm-typescript-template`.
- `check:test` script: drop redundant `--skipLibCheck` (the base config already sets it).

## Verification

- `npm pack --dry-run` now lists `CHANGELOG.md` (12.5kB) in the tarball ✓
- `npm run check`, `npm run check:test`, `npm run lint` all green ✓
- No public API change.

Patch bump (changeset included).